### PR TITLE
Update README to correct SignalR library

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Welcome to the .NET **nanoFramework** SignalR Client Library repository
 
-This API mirrors (as close as possible) the official .NET [Microsoft.AspNet.SignalR.Client](https://docs.microsoft.com/en-us/aspnet/core/signalr/dotnet-client). Exceptions are mainly derived from the lack of `async` and generics support in .NET **nanoFramework**.
+This API mirrors (as close as possible) the official .NET [Microsoft.AspNetCore.SignalR.Client](https://docs.microsoft.com/en-us/aspnet/core/signalr/dotnet-client). Exceptions are mainly derived from the lack of `async` and generics support in .NET **nanoFramework**.
 
 ## Build status
 


### PR DESCRIPTION
[ASP.NET SignalR](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.Client/) is a different product from [ASP.NET Core SignalR](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/), your project is targeting the newer ASP.NET Core one.
https://docs.microsoft.com/aspnet/core/signalr/version-differences?view=aspnetcore-6.0